### PR TITLE
Cmake Build update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,10 @@ project(unpacker VERSION 1.0 LANGUAGES CXX)
 # --- Compiler & build settings ---
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)  # for shared libs
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# Allow user override for install locations (lib, include, bin, etc)
 include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
 
 # --- Dependencies ---
 find_package(ROOT REQUIRED)
@@ -37,9 +37,7 @@ target_link_libraries(unpacker
         ${ROOT_LIBRARIES}
 )
 
-# --- Installation ---
-
-# Libraries (shared/static)
+# --- Install targets ---
 install(TARGETS
     common_unpacking
     common_data_products
@@ -52,44 +50,41 @@ install(TARGETS
     INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
-# Executable
 install(TARGETS unpacker
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
-# Headers
+# --- Install headers ---
 install(DIRECTORY include/
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
-# Export targets for find_package support
+# --- Export targets for find_package ---
 install(EXPORT unpackerTargets
     FILE unpackerTargets.cmake
     NAMESPACE unpacker::
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/unpacker
 )
 
-# --- Config + Version files ---
-include(CMakePackageConfigHelpers)
-
+# --- Package config and version files ---
 write_basic_package_version_file(
-    ${CMAKE_CURRENT_BINARY_DIR}/ConfigVersion.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/unpackerConfigVersion.cmake
     VERSION ${PROJECT_VERSION}
-    COMPATIBILITY AnyNewerVersion
+    COMPATIBILITY SameMajorVersion
 )
 
 configure_package_config_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Config.cmake.in
-    ${CMAKE_CURRENT_BINARY_DIR}/Config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/unpackerConfig.cmake
     INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/unpacker
 )
 
 install(FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/Config.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/ConfigVersion.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/unpackerConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/unpackerConfigVersion.cmake
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/unpacker
 )
 
-# --- RPATH handling ---
+# --- RPATH for local shared lib resolution ---
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ include(${ROOT_USE_FILE})
 include("${ROOT_DIR}/RootMacros.cmake")
 
 find_package(ZLIB REQUIRED)
-find_package(nlohmann_json REQUIRED)
+find_package(nlohmann_json 3.11.2 REQUIRED CONFIG)
 
 # Optional macOS arch override
 set(CMAKE_OSX_ARCHITECTURES "arm64" CACHE STRING "Mac architecture")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ include(${ROOT_USE_FILE})
 include("${ROOT_DIR}/RootMacros.cmake")
 
 find_package(ZLIB REQUIRED)
-find_package(nlohmann_json 3.11.2 REQUIRED CONFIG)
+find_package(nlohmann_json REQUIRED)
 
 # Optional macOS arch override
 set(CMAKE_OSX_ARCHITECTURES "arm64" CACHE STRING "Mac architecture")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,44 +1,35 @@
-project(unpacker)
-
 cmake_minimum_required(VERSION 3.13)
+project(unpacker VERSION 1.0 LANGUAGES CXX)
 
-# for debug
-# set(CMAKE_BUILD_TYPE RelWithDebInfo)
+# --- Compiler & build settings ---
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)  # for shared libs
 
-# ROOT
+# Allow user override for install locations (lib, include, bin, etc)
+include(GNUInstallDirs)
+
+# --- Dependencies ---
 find_package(ROOT REQUIRED)
 include(${ROOT_USE_FILE})
 include("${ROOT_DIR}/RootMacros.cmake")
 
-# ZLIB
 find_package(ZLIB REQUIRED)
-
-# JSON
 find_package(nlohmann_json REQUIRED)
 
-set(CMAKE_CXX_STANDARD 17)
+# Optional macOS arch override
+set(CMAKE_OSX_ARCHITECTURES "arm64" CACHE STRING "Mac architecture")
 
-set(CMAKE_OSX_ARCHITECTURES "arm64")
-
-# Set the path for where to look for the libraries of the installed target
-set(CMAKE_INSTALL_RPATH "${CMAKE_SOURCE_DIR}/lib")
-
-# Create installation directories
-file(MAKE_DIRECTORY ${CMAKE_SOURCE_DIR}/lib)
-file(MAKE_DIRECTORY ${CMAKE_SOURCE_DIR}/bin)
-
-# Add all the subdirectories
+# --- Subdirectories ---
 add_subdirectory(external/midas)
 add_subdirectory(src)
 
-# Create the executable
+# --- Executable ---
 add_executable(unpacker src/main.cc)
-
-# Link libraries
 target_link_libraries(unpacker
     PRIVATE 
         common_data_products
-        common_unpacking 
+        common_unpacking
         nalu_data_products
         nalu_unpacking
         midas
@@ -46,39 +37,71 @@ target_link_libraries(unpacker
         ${ROOT_LIBRARIES}
 )
 
-# Move the dictionaries so that they are next to the .so files
-add_custom_command(
-    TARGET unpacker POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy 
-        ${CMAKE_BINARY_DIR}/src/common/data_products/libcommon_data_products_rdict.pcm
-        ${CMAKE_BINARY_DIR}/src/common/data_products/libcommon_data_products.rootmap
-        ${CMAKE_BINARY_DIR}/src/nalu/data_products/libnalu_data_products_rdict.pcm
-        ${CMAKE_BINARY_DIR}/src/nalu/data_products/libnalu_data_products.rootmap
-        ${CMAKE_BINARY_DIR}/src/common/unpacking/libcommon_unpacking_rdict.pcm
-        ${CMAKE_BINARY_DIR}/src/common/unpacking/libcommon_unpacking.rootmap
-        ${CMAKE_BINARY_DIR}/src/nalu/unpacking/libnalu_unpacking_rdict.pcm
-        ${CMAKE_BINARY_DIR}/src/nalu/unpacking/libnalu_unpacking.rootmap
-        ${CMAKE_SOURCE_DIR}/lib
+# --- Install rules for ROOT dictionaries ---
+# Install generated PCM and rootmap files for libraries:
+foreach(lib common_data_products nalu_data_products common_unpacking nalu_unpacking)
+    install(
+        FILES 
+            ${CMAKE_BINARY_DIR}/src/${lib//_//}/lib${lib}_rdict.pcm
+            ${CMAKE_BINARY_DIR}/src/${lib//_//}/lib${lib}.rootmap
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        OPTIONAL
+    )
+endforeach()
+
+# --- Installation ---
+
+# Libraries (shared/static)
+install(TARGETS
+    common_unpacking
+    common_data_products
+    midas
+    nalu_unpacking
+    nalu_data_products
+    EXPORT unpackerTargets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
-# Install the libraries (including unpacking libs)
-install(TARGETS 
-            common_unpacking
-            common_data_products
-            midas
-            nalu_unpacking
-            nalu_data_products
-        LIBRARY DESTINATION ${CMAKE_SOURCE_DIR}/lib
-)
-
-# Install the executable
+# Executable
 install(TARGETS unpacker
-        DESTINATION ${CMAKE_SOURCE_DIR}/bin
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
-# # Enable debugging symbols
-# target_compile_options(unpacker PRIVATE -g -v)
+# Headers
+install(DIRECTORY include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
 
-# target_compile_options(unpacker PRIVATE -Wall -Wextra -Wno-undef)
+# Export targets for find_package support
+install(EXPORT unpackerTargets
+    FILE unpackerTargets.cmake
+    NAMESPACE unpacker::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/unpacker
+)
 
-# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -v")
+# --- Config + Version files ---
+include(CMakePackageConfigHelpers)
+
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/ConfigVersion.cmake
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY AnyNewerVersion
+)
+
+configure_package_config_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/Config.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/unpacker
+)
+
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/Config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/ConfigVersion.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/unpacker
+)
+
+# --- RPATH handling ---
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ add_subdirectory(src)
 # --- Executable ---
 add_executable(unpacker src/main.cc)
 target_link_libraries(unpacker
-    PRIVATE 
+    PUBLIC 
         common_data_products
         common_unpacking
         nalu_data_products

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,18 +37,6 @@ target_link_libraries(unpacker
         ${ROOT_LIBRARIES}
 )
 
-# --- Install rules for ROOT dictionaries ---
-# Install generated PCM and rootmap files for libraries:
-foreach(lib common_data_products nalu_data_products common_unpacking nalu_unpacking)
-    install(
-        FILES 
-            ${CMAKE_BINARY_DIR}/src/${lib//_//}/lib${lib}_rdict.pcm
-            ${CMAKE_BINARY_DIR}/src/${lib//_//}/lib${lib}.rootmap
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        OPTIONAL
-    )
-endforeach()
-
 # --- Installation ---
 
 # Libraries (shared/static)

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,5 +1,3 @@
 @PACKAGE_INIT@
 
 include("${CMAKE_CURRENT_LIST_DIR}/unpackerTargets.cmake")
-
-find_dependency(nlohmann_json REQUIRED)

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/unpackerTargets.cmake")

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,3 +1,5 @@
 @PACKAGE_INIT@
 
 include("${CMAKE_CURRENT_LIST_DIR}/unpackerTargets.cmake")
+
+find_dependency(nlohmann_json REQUIRED)

--- a/external/midas/CMakeLists.txt
+++ b/external/midas/CMakeLists.txt
@@ -5,6 +5,8 @@ file(GLOB SOURCE_FILES
 add_library(midas SHARED    
     ${SOURCE_FILES}
 )
+add_library(unpacker::midas ALIAS midas)
+
 
 target_include_directories(midas
     PUBLIC

--- a/external/midas/CMakeLists.txt
+++ b/external/midas/CMakeLists.txt
@@ -7,8 +7,9 @@ add_library(midas SHARED
 )
 
 target_include_directories(midas
-    PUBLIC 
-        ${CMAKE_SOURCE_DIR}/external/midas
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/external/midas>
+        $<INSTALL_INTERFACE:include>
 )
 
 target_link_libraries(midas

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -58,12 +58,16 @@ fi
 mkdir -p "$BUILD_DIR"
 cd "$BUILD_DIR" || exit 1
 
-# Run CMake and Make
-echo "[build.sh] Running cmake in: $BUILD_DIR"
-cmake "$BASE_DIR"
+# Define local install prefix (project root)
+LOCAL_INSTALL_PREFIX="$BASE_DIR"
+
+echo "[build.sh] Running cmake with install prefix: $LOCAL_INSTALL_PREFIX"
+cmake -DCMAKE_INSTALL_PREFIX="$LOCAL_INSTALL_PREFIX" "$BASE_DIR"
 
 echo "[build.sh] Building with make $JOBS_ARG"
 make $JOBS_ARG
+
+echo "[build.sh] Installing locally to $LOCAL_INSTALL_PREFIX"
 make install
 
-echo "[build.sh] Build complete."
+echo "[build.sh] Build and install complete."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Resolve absolute paths
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
+BASE_DIR=$(realpath "$SCRIPT_DIR/..")
+BUILD_DIR="$BASE_DIR/build"
+
+# Help message
+show_help() {
+    echo "Usage: ./install.sh"
+    echo
+    echo "Installs the project to the system (default: /usr/local)."
+    echo "This will delete the current build directory before configuring."
+    echo "Note: This will likely require sudo."
+}
+
+# Handle help flag
+if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+    show_help
+    exit 0
+fi
+
+# Always delete previous build directory
+echo "[install.sh] Cleaning previous build at: $BUILD_DIR"
+rm -rf "$BUILD_DIR"
+
+# Create fresh build directory
+mkdir -p "$BUILD_DIR"
+cd "$BUILD_DIR" || exit 1
+
+# Run CMake with default system install prefix
+echo "[install.sh] Re-running CMake with system install prefix (/usr/local)..."
+cmake "$BASE_DIR"
+
+# Install with sudo
+echo "[install.sh] Running 'sudo make install'..."
+make -j
+sudo make install
+
+echo "[install.sh] Install complete to system default (/usr/local)"

--- a/src/common/data_products/CMakeLists.txt
+++ b/src/common/data_products/CMakeLists.txt
@@ -7,6 +7,7 @@ file(GLOB SOURCE_FILES
 
 # Make an object file
 add_library(common_data_products SHARED ${SOURCE_FILES})
+add_library(unpacker::common_data_products ALIAS common_data_products)
 
 # Include directories - use generator expressions for build vs install
 target_include_directories(common_data_products

--- a/src/common/data_products/CMakeLists.txt
+++ b/src/common/data_products/CMakeLists.txt
@@ -1,3 +1,5 @@
+# Example for common_data_products - apply similar pattern to others
+
 # Glob the source files together
 file(GLOB SOURCE_FILES
     *.cc
@@ -6,12 +8,12 @@ file(GLOB SOURCE_FILES
 # Make an object file
 add_library(common_data_products SHARED ${SOURCE_FILES})
 
-# Include directories
+# Include directories - use generator expressions for build vs install
 target_include_directories(common_data_products
     PUBLIC
-        ${CMAKE_SOURCE_DIR}/include
-        ${ROOT_INCLUDE_DIRS}
-
+        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+        $<BUILD_INTERFACE:${ROOT_INCLUDE_DIRS}>
 )
 
 # Libraries
@@ -20,7 +22,7 @@ target_link_libraries(common_data_products
         ${ROOT_LIBRARIES}
 )
 
-#These are the data products for which we make root dictionaries
+# These are the data products for which we make root dictionaries
 set(CommonDataProducts 
     ${CMAKE_SOURCE_DIR}/include/common/data_products/*.hh
 )
@@ -29,4 +31,13 @@ root_generate_dictionary(CommonDataProductDictionary
     ${CommonDataProducts} 
     MODULE common_data_products
     LINKDEF ${CMAKE_SOURCE_DIR}/include/common/data_products/LinkDef.h
+)
+
+# Install the ROOT dictionary files generated for this library
+install(
+    FILES 
+        ${CMAKE_CURRENT_BINARY_DIR}/libcommon_data_products_rdict.pcm
+        ${CMAKE_CURRENT_BINARY_DIR}/libcommon_data_products.rootmap
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    OPTIONAL
 )

--- a/src/common/unpacking/CMakeLists.txt
+++ b/src/common/unpacking/CMakeLists.txt
@@ -42,9 +42,10 @@ add_library(common_unpacking SHARED
 # Set include paths for compilation
 target_include_directories(common_unpacking
     PUBLIC
-        ${CMAKE_SOURCE_DIR}/include
-        ${CMAKE_SOURCE_DIR}/external/midas
-        ${ROOT_INCLUDE_DIRS}
+        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/external/midas>
+        $<INSTALL_INTERFACE:include>
+        $<BUILD_INTERFACE:${ROOT_INCLUDE_DIRS}>
 )
 
 # Link dependencies
@@ -54,4 +55,13 @@ target_link_libraries(common_unpacking
         midas
         nlohmann_json::nlohmann_json
         ${ROOT_LIBRARIES}
+)
+
+# Install the ROOT dictionary files generated for this library
+install(
+    FILES 
+        ${CMAKE_CURRENT_BINARY_DIR}/libcommon_unpacking_rdict.pcm
+        ${CMAKE_CURRENT_BINARY_DIR}/libcommon_unpacking.rootmap
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    OPTIONAL
 )

--- a/src/common/unpacking/CMakeLists.txt
+++ b/src/common/unpacking/CMakeLists.txt
@@ -38,6 +38,8 @@ add_library(common_unpacking SHARED
     ${SOURCE_FILES}
     common_unpacking_dict.cxx
 )
+add_library(unpacker::common_unpacking ALIAS common_unpacking)
+
 
 # Set include paths for compilation
 target_include_directories(common_unpacking

--- a/src/common/unpacking/CMakeLists.txt
+++ b/src/common/unpacking/CMakeLists.txt
@@ -36,7 +36,7 @@ root_generate_dictionary(common_unpacking_dict
 # Add library with ROOT dictionary source
 add_library(common_unpacking SHARED
     ${SOURCE_FILES}
-    common_unpacking_dict.cxx
+    ${CMAKE_CURRENT_BINARY_DIR}/common_unpacking_dict.cxx
 )
 add_library(unpacker::common_unpacking ALIAS common_unpacking)
 

--- a/src/main_new.cc
+++ b/src/main_new.cc
@@ -1,0 +1,317 @@
+/*
+Some description...
+*/
+
+// Standard
+#include <iostream>
+#include <memory>
+#include <fstream>
+#include <time.h>
+#include <filesystem>
+#include <string>
+#include <sstream>
+#include <vector>
+
+// ROOT
+#include <TFile.h>
+#include <TTree.h>
+#include <TBufferJSON.h>
+#include <TSystem.h>
+#include <TClass.h>
+#include <TDataMember.h>
+
+// Custom - Common
+#include "common/unpacking/Logger.hh"
+
+// Custom - Nalu
+#include "nalu/unpacking/NaluEventUnpacker.hh"
+#include "nalu/data_products/NaluEventHeader.hh"
+#include "nalu/data_products/NaluPacketHeader.hh"
+#include "nalu/data_products/NaluWaveform.hh"
+#include "nalu/data_products/NaluPacketFooter.hh"
+#include "nalu/data_products/NaluEventFooter.hh"
+#include "nalu/data_products/NaluTime.hh"
+#include "nalu/data_products/NaluODB.hh"
+
+
+// Helper function to print ROOT class reflection info
+void PrintRootClassInfo(const char* className)
+{
+    TClass* cls = TClass::GetClass(className);
+    if (!cls) {
+        std::cout << "Class " << className << " not found by ROOT dictionary!" << std::endl;
+        return;
+    }
+
+    std::cout << "Class: " << cls->GetName() << std::endl;
+    std::cout << "Title: " << cls->GetTitle() << std::endl;
+    std::cout << "Number of Data Members: " << cls->GetListOfDataMembers()->GetEntries() << std::endl;
+
+    TIter next(cls->GetListOfDataMembers());
+    TDataMember* dm;
+    while ((dm = (TDataMember*)next())) {
+        std::cout << " - " << dm->GetName() << " (" << dm->GetTypeName() << ")" << std::endl;
+    }
+    std::cout << std::endl;
+}
+
+
+// Helper function to print ROOT class members and their values (basic types only)
+void PrintMembersFromBase(const dataProducts::DataProduct* obj) {
+    if (!obj) {
+        std::cout << "[PrintMembersFromBase] Null pointer received." << std::endl;
+        return;
+    }
+
+    TClass* actualClass = TClass::GetClass(typeid(*obj));
+    if (!actualClass) {
+        std::cout << "[PrintMembersFromBase] Could not determine class for object." << std::endl;
+        return;
+    }
+
+    std::cout << "\n== Runtime type: " << actualClass->GetName() << " ==" << std::endl;
+
+    const TCollection* membersList = cls->GetListOfDataMembers();
+    TIter next(membersList);
+    TDataMember* dm;
+    while ((dm = (TDataMember*)next())) {
+        Long_t offset = dm->GetOffset();
+        const char* memberName = dm->GetName();
+        const char* typeName = dm->GetTypeName();
+        void* memberPtr = (char*)obj + offset;
+
+        std::cout << " - " << memberName << " (" << typeName << ") = ";
+
+        if (strcmp(typeName, "int") == 0) {
+            std::cout << *(int*)memberPtr;
+        } else if (strcmp(typeName, "unsigned int") == 0) {
+            std::cout << *(unsigned int*)memberPtr;
+        } else if (strcmp(typeName, "unsigned short") == 0) {
+            std::cout << *(unsigned short*)memberPtr;
+        } else if (strcmp(typeName, "unsigned long") == 0) {
+            std::cout << *(unsigned long*)memberPtr;
+        } else if (strcmp(typeName, "double") == 0) {
+            std::cout << *(double*)memberPtr;
+        } else if (strcmp(typeName, "std::string") == 0 || strcmp(typeName, "string") == 0) {
+            std::cout << *(std::string*)memberPtr;
+        } else if (strstr(typeName, "vector") != nullptr) {
+            std::cout << "[vector]";
+        } else {
+            std::cout << "<unsupported type>";
+        }
+
+        std::cout << std::endl;
+    }
+}
+
+
+int main(int argc, char *argv[])
+{
+    // -----------------------------------------------------------------------------------------------
+    // Parse command line arguments
+
+    // We need three arguments: program & file name & verbosity
+    if (argc != 3) {
+        std::cerr << "Usage: " << argv[0] << " input_file_name verbosity" << std::endl;
+        return 1;
+    }
+
+    // input file name
+    std::string input_file_name = argv[1];
+
+    int verbosity = std::atoi(argv[2]);
+
+    // Check if input file exists
+    if (!std::filesystem::exists(input_file_name)) {
+        std::cerr << "Input file doesn't exist. Could not find " << input_file_name << std::endl;
+        return 1;
+    }
+
+    // output file name
+    std::string output_file_name;
+    output_file_name = input_file_name.substr(input_file_name.find_last_of("/\\") + 1);
+    output_file_name = output_file_name.substr(0, output_file_name.find_last_of('.')) + ".root";
+    std::cout << "Output file: " << output_file_name << std::endl;
+
+    // Set verbosity for unpacker
+    utils::LoggerHolder::getInstance().SetVerbosity(verbosity);
+
+    // End of parsing command line arguments
+    // -----------------------------------------------------------------------------------------------
+
+    // create the output file structure
+    TFile *outfile = new TFile(output_file_name.c_str(),"RECREATE");
+
+    // Compression settings
+    // outfile->SetCompressionLevel(0); // no compression, faster but bigger
+    outfile->SetCompressionAlgorithm(4); // LZ4 compression: faster & decent size
+
+    TTree *tree = new TTree("tree", "tree");
+
+    dataProducts::NaluEventHeaderCollection nalu_event_headers;
+    tree->Branch("nalu_event_headers", &nalu_event_headers);
+
+    dataProducts::NaluPacketHeaderCollection nalu_packet_headers;
+    tree->Branch("nalu_packet_headers", &nalu_packet_headers);
+
+    dataProducts::NaluWaveformCollection nalu_waveforms;
+    tree->Branch("nalu_waveforms", &nalu_waveforms);
+
+    dataProducts::NaluPacketFooterCollection nalu_packet_footers;
+    tree->Branch("nalu_packet_footers", &nalu_packet_footers);
+
+    dataProducts::NaluEventFooterCollection nalu_event_footers;
+    tree->Branch("nalu_event_footers", &nalu_event_footers);
+
+    dataProducts::NaluTimeCollection nalu_times;
+    tree->Branch("nalu_times", &nalu_times);
+
+    dataProducts::NaluODB odb;
+
+    // -----------------------------------------------------------------------------------------------
+
+    // Set up an event unpacker object
+    auto eventUnpacker = new unpackers::NaluEventUnpacker();
+
+    // Create MIDAS reader
+    TMReaderInterface *mReader = TMNewReader(input_file_name.c_str());
+
+    int nTotalMidasEvents = 0;
+    int nSkippedMidasEvents = 0;
+
+    // Loop over the events
+    while (true)
+    {
+        TMEvent *thisEvent = TMReadEvent(mReader);
+        if (!thisEvent || nTotalMidasEvents > 100)
+        {
+            // Reached end of file or limit reached
+            delete thisEvent;
+            break;
+        }
+
+        if (thisEvent->serial_number % 100 == 0) {
+            std::cout << "event_id: " << thisEvent->event_id << ", serial number: " << thisEvent->serial_number << std::endl;
+        }
+
+        int event_id = thisEvent->event_id;
+
+        // Check internal MIDAS event
+        if (unpackers::IsHeaderEvent(thisEvent)) {
+            // Check if BOR event
+            if (event_id == 32768) {
+                std::vector<char> data = thisEvent->data;
+                std::string odb_dump(data.begin(), data.end());
+                std::size_t pos = odb_dump.find('{');
+                if (pos != std::string::npos) {
+                    odb_dump.erase(0, pos);  // Keep from first '{'
+                }
+                odb = dataProducts::NaluODB(odb_dump);
+                outfile->WriteObject(&odb, "nalu_odb");
+            }
+            delete thisEvent;
+            continue;
+        }
+
+        thisEvent->FindAllBanks();
+
+        if (event_id > 0) {
+            nTotalMidasEvents++;
+
+            int status = eventUnpacker->UnpackEvent(thisEvent);
+
+            if (status != 0) {
+                delete thisEvent;
+                nSkippedMidasEvents++;
+                continue;
+            }
+
+            nalu_event_headers = eventUnpacker->GetCollection<dataProducts::NaluEventHeader>("NaluEventHeaderCollection");
+            nalu_packet_headers = eventUnpacker->GetCollection<dataProducts::NaluPacketHeader>("NaluPacketHeaderCollection");
+            nalu_waveforms = eventUnpacker->GetCollection<dataProducts::NaluWaveform>("NaluWaveformCollection");
+            nalu_packet_footers = eventUnpacker->GetCollection<dataProducts::NaluPacketFooter>("NaluPacketFooterCollection");
+            nalu_event_footers = eventUnpacker->GetCollection<dataProducts::NaluEventFooter>("NaluEventFooterCollection");
+            nalu_times = eventUnpacker->GetCollection<dataProducts::NaluTime>("NaluTimeCollection");
+
+            if (nTotalMidasEvents <= 1) {
+                std::cout << "\n=== Example print of first object members from each collection ===" << std::endl;
+
+                if (!nalu_event_headers.empty())
+                    PrintMembersFromBase(&nalu_event_headers[0]);
+                if (!nalu_packet_headers.empty())
+                    PrintMembersFromBase(&nalu_packet_headers[0]);
+                if (!nalu_waveforms.empty())
+                    PrintMembersFromBase(&nalu_waveforms[0]);
+                if (!nalu_packet_footers.empty())
+                    PrintMembersFromBase(&nalu_packet_footers[0]);
+                if (!nalu_event_footers.empty())
+                    PrintMembersFromBase(&nalu_event_footers[0]);
+                if (!nalu_times.empty())
+                    PrintMembersFromBase(&nalu_times[0]);
+            }
+
+            tree->Fill();
+
+            nalu_event_headers.clear();
+            nalu_packet_headers.clear();
+            nalu_waveforms.clear();
+            nalu_packet_footers.clear();
+            nalu_event_footers.clear();
+            nalu_times.clear();
+        }
+
+        delete thisEvent;
+    } // end loop over events
+
+    // Write tree and close output file
+    tree->Write();
+    outfile->Close();
+
+    // Print ROOT reflection info for data products
+    std::cout << "\n=== ROOT Reflection Info for Data Products ===\n";
+    PrintRootClassInfo("dataProducts::NaluEventHeader");
+    PrintRootClassInfo("dataProducts::NaluPacketHeader");
+    PrintRootClassInfo("dataProducts::NaluWaveform");
+    PrintRootClassInfo("dataProducts::NaluPacketFooter");
+    PrintRootClassInfo("dataProducts::NaluEventFooter");
+    PrintRootClassInfo("dataProducts::NaluTime");
+    PrintRootClassInfo("dataProducts::NaluODB");
+
+
+    // Cleanup
+    delete eventUnpacker;
+    delete mReader;
+
+    std::cout << "Skipped " << nSkippedMidasEvents << "/" << nTotalMidasEvents << " midas events" << std::endl;
+    std::cout << "All done!" << std::endl;
+
+
+
+    // Test creating a new NaluEventUnpacker instance dynamically via ROOT dictionary
+    TClass* unpackerClass = TClass::GetClass("unpackers::NaluEventUnpacker");
+    if (!unpackerClass) {
+        std::cerr << "ERROR: ROOT dictionary for unpackers::NaluEventUnpacker not found!" << std::endl;
+    } else {
+        // Add explicit cast from void* to TObject*
+        TObject* obj = static_cast<TObject*>(unpackerClass->New());
+        if (!obj) {
+            std::cerr << "ERROR: Failed to instantiate unpackers::NaluEventUnpacker via ROOT!" << std::endl;
+        } else {
+            std::cout << "Successfully created a new unpackers::NaluEventUnpacker instance via ROOT!" << std::endl;
+            
+            // You can cast to proper type if you want to use it normally
+            unpackers::NaluEventUnpacker* unpackerPtr = dynamic_cast<unpackers::NaluEventUnpacker*>(obj);
+            if (unpackerPtr) {
+                // Use unpackerPtr as usual here, e.g., call methods, etc.
+                std::cout << "Unpacker instance ready to use." << std::endl;
+            } else {
+                std::cerr << "ERROR: dynamic_cast failed on the created object." << std::endl;
+            }
+            
+            delete obj; // Clean up
+        }
+    }
+
+
+    return 0;
+}

--- a/src/nalu/data_products/CMakeLists.txt
+++ b/src/nalu/data_products/CMakeLists.txt
@@ -5,6 +5,8 @@ file(GLOB SOURCE_FILES
 
 # Make an object file
 add_library(nalu_data_products SHARED ${SOURCE_FILES})
+add_library(unpacker::nalu_data_products ALIAS nalu_data_products)
+
 
 # Include directories
 target_include_directories(nalu_data_products

--- a/src/nalu/data_products/CMakeLists.txt
+++ b/src/nalu/data_products/CMakeLists.txt
@@ -9,7 +9,8 @@ add_library(nalu_data_products SHARED ${SOURCE_FILES})
 # Include directories
 target_include_directories(nalu_data_products
     PUBLIC
-        ${CMAKE_SOURCE_DIR}/include
+        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
 )
 
 # Libraries
@@ -18,7 +19,7 @@ target_link_libraries(nalu_data_products
         common_data_products
 )
 
-#These are the data products for which we make root dictionaries
+# These are the data products for which we make root dictionaries
 set(NaluDataProducts 
     ${CMAKE_SOURCE_DIR}/include/nalu/data_products/*.hh
 )
@@ -27,4 +28,13 @@ root_generate_dictionary(NaluDataProductDictionary
     ${NaluDataProducts} 
     MODULE nalu_data_products
     LINKDEF ${CMAKE_SOURCE_DIR}/include/nalu/data_products/LinkDef.h
+)
+
+# Install the ROOT dictionary files generated for this library
+install(
+    FILES 
+        ${CMAKE_CURRENT_BINARY_DIR}/libnalu_data_products_rdict.pcm
+        ${CMAKE_CURRENT_BINARY_DIR}/libnalu_data_products.rootmap
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    OPTIONAL
 )

--- a/src/nalu/unpacking/CMakeLists.txt
+++ b/src/nalu/unpacking/CMakeLists.txt
@@ -36,7 +36,7 @@ root_generate_dictionary(nalu_unpacking_dict
 # Add library with ROOT dictionary source
 add_library(nalu_unpacking SHARED
     ${SOURCE_FILES}
-    nalu_unpacking_dict.cxx
+    ${CMAKE_CURRENT_BINARY_DIR}/nalu_unpacking_dict.cxx
 )
 
 # Set include paths for compilation

--- a/src/nalu/unpacking/CMakeLists.txt
+++ b/src/nalu/unpacking/CMakeLists.txt
@@ -42,8 +42,9 @@ add_library(nalu_unpacking SHARED
 # Set include paths for compilation
 target_include_directories(nalu_unpacking
     PUBLIC
-        ${CMAKE_SOURCE_DIR}/include
-        ${ROOT_INCLUDE_DIRS}
+        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+        $<BUILD_INTERFACE:${ROOT_INCLUDE_DIRS}>
 )
 
 # Link dependencies
@@ -52,4 +53,13 @@ target_link_libraries(nalu_unpacking
         common_unpacking
         nalu_data_products
         ${ROOT_LIBRARIES}
+)
+
+# Install the ROOT dictionary files generated for this library
+install(
+    FILES 
+        ${CMAKE_CURRENT_BINARY_DIR}/libnalu_unpacking_rdict.pcm
+        ${CMAKE_CURRENT_BINARY_DIR}/libnalu_unpacking.rootmap
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    OPTIONAL
 )

--- a/src/nalu/unpacking/CMakeLists.txt
+++ b/src/nalu/unpacking/CMakeLists.txt
@@ -54,6 +54,8 @@ target_link_libraries(nalu_unpacking
         nalu_data_products
         ${ROOT_LIBRARIES}
 )
+add_library(unpacker::nalu_unpacking ALIAS nalu_unpacking)
+
 
 # Install the ROOT dictionary files generated for this library
 install(


### PR DESCRIPTION
Refactored CMakeLists.txts to be more friendly to system wide installations.

A few key notes:
1. `make install` no longer defaults to local install (build.sh will automatically set -DCMAKE_INSTALL_PREFIX for local install, where install.sh will install in the user's default install prefix, which is usually /usr/local)
2. Installation of root libraries is now handled by the CMakeLists.txt directory they correspond to
3. Added Config.cmake.in to allow CMake to easily find libraries findpackage. Example:
```
# Find your unpacker package
find_package(unpacker REQUIRED)

# Also find ROOT since your unpacker uses it
find_package(ROOT REQUIRED)

# Create your executable
add_executable(my_analysis main.cpp)

# Link against the unpacker libraries
target_link_libraries(my_analysis
    PRIVATE
        unpacker::common_data_products
        unpacker::common_unpacking
        unpacker::nalu_data_products
        unpacker::nalu_unpacking
        unpacker::midas
        ${ROOT_LIBRARIES}
)

```